### PR TITLE
(暫定)Bugsnag 5.xに依存させる

### DIFF
--- a/bugsnag-delivery-fluent.gemspec
+++ b/bugsnag-delivery-fluent.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rspec-mocks'
 
-  spec.add_runtime_dependency 'bugsnag'
+  spec.add_runtime_dependency 'bugsnag', "~> 5.0"
   spec.add_runtime_dependency 'fluent-logger'
 end

--- a/lib/bugsnag/delivery/fluent/version.rb
+++ b/lib/bugsnag/delivery/fluent/version.rb
@@ -1,7 +1,7 @@
 module Bugsnag
   module Delivery
     class Fluent
-      VERSION = "0.1.3"
+      VERSION = "0.1.4"
     end
   end
 end


### PR DESCRIPTION
Bugsnag 6系がリリースされていますが、`delivery` のシグネチャに非互換があるようなので、とりあえず依存関係で誤魔化す修正です。

Bugsnag 6系では `deliver` メソッドの[引数の数が4つ](https://github.com/bugsnag/bugsnag-ruby/blob/fb71a8fb6c9e8b46e372525d6b26bb990bb82918/lib/bugsnag.rb#L119)になっています
