### PR TITLE
Bugsnag 6.x

### DIFF
--- a/bugsnag-delivery-fluent.gemspec
+++ b/bugsnag-delivery-fluent.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rspec-mocks'
 
-  spec.add_runtime_dependency 'bugsnag', "~> 5.0"
+  spec.add_runtime_dependency 'bugsnag', '~> 6.0'
   spec.add_runtime_dependency 'fluent-logger'
 end

--- a/lib/bugsnag/delivery/fluent.rb
+++ b/lib/bugsnag/delivery/fluent.rb
@@ -31,15 +31,15 @@ module Bugsnag
             :port => configuration.fluent_port
           )
           if logger.post('deliver', { :url => url, :body => body })
-            Bugsnag.debug("Notification to #{url} finished, payload was #{body}")
+            configuration.debug("Notification to #{url} finished, payload was #{body}")
           else
-            Bugsnag.warn("Notification to #{url} failed, #{logger.last_error}")
+            configuration.warn("Notification to #{url} failed, #{logger.last_error}")
           end
         rescue StandardError => e
           raise if e.class.to_s == "RSpec::Expectations::ExpectationNotMetError"
 
-          Bugsnag.warn("Notification to #{url} failed, #{e.inspect}")
-          Bugsnag.warn(e.backtrace)
+          configuration.warn("Notification to #{url} failed, #{e.inspect}")
+          configuration.warn(e.backtrace)
         end
       end
     end

--- a/lib/bugsnag/delivery/fluent.rb
+++ b/lib/bugsnag/delivery/fluent.rb
@@ -23,7 +23,7 @@ module Bugsnag
 
   module Delivery
     class Fluent
-      def self.deliver(url, body, configuration)
+      def self.deliver(url, body, configuration, options = {})
         begin
           logger = ::Fluent::Logger::FluentLogger.new(
             configuration.fluent_tag_prefix,

--- a/lib/bugsnag/delivery/fluent/version.rb
+++ b/lib/bugsnag/delivery/fluent/version.rb
@@ -1,7 +1,7 @@
 module Bugsnag
   module Delivery
     class Fluent
-      VERSION = "0.1.4"
+      VERSION = "0.2.0"
     end
   end
 end

--- a/spec/bugsnag/delivery/fluent_spec.rb
+++ b/spec/bugsnag/delivery/fluent_spec.rb
@@ -29,7 +29,7 @@ describe Bugsnag::Delivery::Fluent do
 
       it do
         expect(fluent_logger).to_not receive(:last_error)
-        expect(Bugsnag).to_not receive(:warn)
+        expect(configuration).to_not receive(:warn)
         subject
       end
     end
@@ -42,7 +42,7 @@ describe Bugsnag::Delivery::Fluent do
 
         it do
           expect(fluent_logger).to receive(:last_error).and_return('LAST ERROR')
-          expect(Bugsnag).to receive(:warn).with('Notification to http://www.example.com/ failed, LAST ERROR')
+          expect(configuration).to receive(:warn).with('Notification to http://www.example.com/ failed, LAST ERROR')
           subject
         end
       end
@@ -54,7 +54,7 @@ describe Bugsnag::Delivery::Fluent do
 
         it do
           expect(fluent_logger).to_not receive(:last_error)
-          expect(Bugsnag).to receive(:warn).exactly(2).times
+          expect(configuration).to receive(:warn).exactly(2).times
           subject
         end
       end

--- a/spec/bugsnag/delivery/fluent_spec.rb
+++ b/spec/bugsnag/delivery/fluent_spec.rb
@@ -20,7 +20,7 @@ describe Bugsnag::Delivery::Fluent do
       expect(::Fluent::Logger::FluentLogger).to receive(:new).and_return(fluent_logger)
     end
 
-    subject { described_class.deliver(url, body, configuration) }
+    subject { described_class.deliver(url, body, configuration, {}) }
 
     context 'send successful' do
       before do


### PR DESCRIPTION
Why
----

Bugsnag 6.x での breaking changes に対応できていないため、Bugsnag 5.x から 6.x にアップデートする事ができない状況。

How
----

- [x] `Bugsnag::Delivery::Fluent.deliver` に第四引数を追加
- [x] `Bugsnag.warn` の様なロギングメソッドは `Bugsnag::Configuration` のものを使う

Check
----

- [x] CI
- [x] 簡易動作確認