### PR TITLE
Bugsnag API のペイロードに apiKey を含めるために Bugsnag 6.6.3 以上を使う

### DIFF
--- a/bugsnag-delivery-fluent.gemspec
+++ b/bugsnag-delivery-fluent.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rspec-mocks'
 
-  spec.add_runtime_dependency 'bugsnag', '~> 6.0'
+  spec.add_runtime_dependency 'bugsnag', '~> 6.0', '>= 6.6.3'
   spec.add_runtime_dependency 'fluent-logger'
 end

--- a/lib/bugsnag/delivery/fluent/version.rb
+++ b/lib/bugsnag/delivery/fluent/version.rb
@@ -1,7 +1,7 @@
 module Bugsnag
   module Delivery
     class Fluent
-      VERSION = "0.2.0"
+      VERSION = "0.2.1"
     end
   end
 end


### PR DESCRIPTION
#2 で 6.x 対応をしたが、6.6.2 以下だとペイロードに apiKey が含まれず、fluent-logger でバッファに書き込む際に Bugsnag の API キーを渡す事ができなくなっていた。