### PR TITLE
HTTP リクエストヘッダを指定できる様に options 引数を渡す

### DIFF
--- a/lib/bugsnag/delivery/fluent.rb
+++ b/lib/bugsnag/delivery/fluent.rb
@@ -30,7 +30,7 @@ module Bugsnag
             :host => configuration.fluent_host,
             :port => configuration.fluent_port
           )
-          if logger.post('deliver', { :url => url, :body => body })
+          if logger.post('deliver', { :url => url, :body => body, :options => options })
             configuration.debug("Notification to #{url} finished, payload was #{body}")
           else
             configuration.warn("Notification to #{url} failed, #{logger.last_error}")

--- a/lib/bugsnag/delivery/fluent/version.rb
+++ b/lib/bugsnag/delivery/fluent/version.rb
@@ -1,7 +1,7 @@
 module Bugsnag
   module Delivery
     class Fluent
-      VERSION = "0.2.1"
+      VERSION = "0.2.2"
     end
   end
 end

--- a/spec/bugsnag/delivery/fluent_spec.rb
+++ b/spec/bugsnag/delivery/fluent_spec.rb
@@ -20,11 +20,12 @@ describe Bugsnag::Delivery::Fluent do
       expect(::Fluent::Logger::FluentLogger).to receive(:new).and_return(fluent_logger)
     end
 
-    subject { described_class.deliver(url, body, configuration, {}) }
+    subject { described_class.deliver(url, body, configuration, { headers: { 'Bugsnag-Payload-Version' => '4.0' } }) }
 
     context 'send successful' do
       before do
-        expect(fluent_logger).to receive(:post).with('deliver', { :url => url, :body => body }).and_return(true)
+        data = { :url => url, :body => body, :options => { headers: { 'Bugsnag-Payload-Version' => '4.0' } } }
+        expect(fluent_logger).to receive(:post).with('deliver', data).and_return(true)
       end
 
       it do
@@ -37,7 +38,8 @@ describe Bugsnag::Delivery::Fluent do
     context 'send failed' do
       context 'fluent logger return false' do
         before do
-          expect(fluent_logger).to receive(:post).with('deliver', { :url => url, :body => body }).and_return(false)
+          data = { :url => url, :body => body, :options => { headers: { 'Bugsnag-Payload-Version' => '4.0' } } }
+          expect(fluent_logger).to receive(:post).with('deliver', data).and_return(false)
         end
 
         it do
@@ -49,7 +51,8 @@ describe Bugsnag::Delivery::Fluent do
 
       context 'fluent logger raise exception' do
         before do
-          expect(fluent_logger).to receive(:post).with('deliver', { :url => url, :body => body }).and_raise
+          data = { :url => url, :body => body, :options => { headers: { 'Bugsnag-Payload-Version' => '4.0' } } }
+          expect(fluent_logger).to receive(:post).with('deliver', data).and_raise
         end
 
         it do


### PR DESCRIPTION
delvier メソッドの第四引数 `options` に HTTP リクエストヘッダが含まれる。

Bugsnag v6 ではリクエストボディに `payloadVersion` が含まれないため、 `Bugsnag-Payload-Version` ヘッダでバージョンを明示できる様にしたい。
これを指定しなかった場合、severity が info として処理される模様。

### 関連

https://github.com/feedforce/fluent-plugin-bugsnag/pull/1