### PR TITLE
Close connection after deliver data

### DIFF
--- a/lib/bugsnag/delivery/fluent.rb
+++ b/lib/bugsnag/delivery/fluent.rb
@@ -24,6 +24,7 @@ module Bugsnag
   module Delivery
     class Fluent
       def self.deliver(url, body, configuration, options = {})
+        logger = nil
         begin
           logger = ::Fluent::Logger::FluentLogger.new(
             configuration.fluent_tag_prefix,
@@ -40,6 +41,8 @@ module Bugsnag
 
           configuration.warn("Notification to #{url} failed, #{e.inspect}")
           configuration.warn(e.backtrace)
+        ensure
+          logger.close if logger
         end
       end
     end

--- a/spec/bugsnag/delivery/fluent_spec.rb
+++ b/spec/bugsnag/delivery/fluent_spec.rb
@@ -16,19 +16,17 @@ describe Bugsnag::Delivery::Fluent do
     let(:configuration) { Bugsnag.configuration }
     let(:post_result) { nil }
 
-    before do
-      expect(::Fluent::Logger::FluentLogger).to receive(:new).and_return(fluent_logger)
-    end
-
     subject { described_class.deliver(url, body, configuration, { headers: { 'Bugsnag-Payload-Version' => '4.0' } }) }
 
     context 'send successful' do
       before do
+        expect(::Fluent::Logger::FluentLogger).to receive(:new).and_return(fluent_logger)
         data = { :url => url, :body => body, :options => { headers: { 'Bugsnag-Payload-Version' => '4.0' } } }
         expect(fluent_logger).to receive(:post).with('deliver', data).and_return(true)
       end
 
       it do
+        expect(fluent_logger).to receive(:close)
         expect(fluent_logger).to_not receive(:last_error)
         expect(configuration).to_not receive(:warn)
         subject
@@ -38,11 +36,13 @@ describe Bugsnag::Delivery::Fluent do
     context 'send failed' do
       context 'fluent logger return false' do
         before do
+          expect(::Fluent::Logger::FluentLogger).to receive(:new).and_return(fluent_logger)
           data = { :url => url, :body => body, :options => { headers: { 'Bugsnag-Payload-Version' => '4.0' } } }
           expect(fluent_logger).to receive(:post).with('deliver', data).and_return(false)
         end
 
         it do
+          expect(fluent_logger).to receive(:close)
           expect(fluent_logger).to receive(:last_error).and_return('LAST ERROR')
           expect(configuration).to receive(:warn).with('Notification to http://www.example.com/ failed, LAST ERROR')
           subject
@@ -51,15 +51,27 @@ describe Bugsnag::Delivery::Fluent do
 
       context 'fluent logger raise exception' do
         before do
+          expect(::Fluent::Logger::FluentLogger).to receive(:new).and_return(fluent_logger)
           data = { :url => url, :body => body, :options => { headers: { 'Bugsnag-Payload-Version' => '4.0' } } }
           expect(fluent_logger).to receive(:post).with('deliver', data).and_raise
         end
 
         it do
+          expect(fluent_logger).to receive(:close)
           expect(fluent_logger).to_not receive(:last_error)
           expect(configuration).to receive(:warn).exactly(2).times
           subject
         end
+      end
+    end
+
+    context 'connection failure' do
+      it 'return' do
+        exception = StandardError.new('Connection Failure')
+        expect(Fluent::Logger::FluentLogger).to receive(:new).and_raise(exception)
+        expect(configuration).to receive(:warn).exactly(2).times
+
+        subject
       end
     end
   end


### PR DESCRIPTION
Why
----

The `Bugsnag::Delivery::Fluent.deliver` establish connection with fluentd using `Fluent::Logger::FluentLogger.new`, but not closing connection.

How
----

- [x] close connection in `Bugsnag::Delivery::Fluent.deliver`

Verify
----

```
[mac]% /opt/td-agent/usr/sbin/td-agent --version
td-agent 1.0.2
[mac]% sudo /opt/td-agent/embedded/bin/fluent-gem install fluent-plugin-bugsnag
[mac]% /opt/td-agent/usr/sbin/td-agent -c /dev/null -i '<match bugsnag.deliver>\n@type bugsnag\n</match>'
```

```ruby
require 'bundler/setup'
require 'bugsnag/delivery/fluent'

Bugsnag.configure do |config|
  config.api_key = '<Bugsnag API Key>'
  config.delivery_method = :fluent
end
Bugsnag.notify(StandardError.new('### ### TEST 1'))
Bugsnag.notify(StandardError.new('### ### TEST 2'))
```

Out of Scope
----

- reuse instance of `Fluent::Logger::FluentLogger`